### PR TITLE
Correct data source for java8 cart and flatMap take benchmarks

### DIFF
--- a/src/main/java/benchmarks/S.java
+++ b/src/main/java/benchmarks/S.java
@@ -101,7 +101,7 @@ public class S {
 
    @Benchmark
    public int cart_java8() {
-      int cart = IntStream.of(v)
+      int cart = IntStream.of(v_outer)
       .flatMap(d -> IntStream.of(v_inner).map(dP -> dP * d))
       .sum();
 
@@ -175,7 +175,7 @@ public class S {
 
    @Benchmark
    public int flatMap_take_java8() {
-      int sum = IntStream.of(v).flatMap(x -> IntStream.of(v_inner).map(dP -> dP * x))
+      int sum = IntStream.of(v_outer).flatMap(x -> IntStream.of(v_inner).map(dP -> dP * x))
       .limit(20000000)
       .sum();
       return sum;


### PR DESCRIPTION
The java 8 version of the cart benchmark suffers from a 10x increased workload compared to the baseline due to a typo.
This brings the time per iteration down to 400-600ms on my machine, compared to >2000ms.
Performance of the flatMap benchmark is naturally unchanged.